### PR TITLE
Create EncodeToImage functions for both secure and normal methods

### DIFF
--- a/global.go
+++ b/global.go
@@ -23,6 +23,7 @@ func RsEncode(data []byte, parity int) ([]byte, error) {
 func RsDecode(packedDataShards []byte, parity int) ([]byte, error) {
 	return u.RsDecode(packedDataShards, 1, parity)
 }
+
 // GetImageCapacity calculates the maximum amount of data (in bytes)
 // that can be embedded in the given image, based on the specified bit depth.
 // Returns 0 if the bit depth exceeds 7, as higher depths are unsupported.


### PR DESCRIPTION
Hi, I just added 2 functions to encode the image data to a returning `image.Image` value because I found this library lacking this function. All of the code works, and all tests pass. Hope this can be merged into the next release. Thank you.